### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
    "description" : "Describe Tinky Workflows in JSON",
    "name" : "Tinky::JSON",
-   "license" : "Artistic",
+   "license" : "Artistic-2.0",
    "perl" : "6.c",
    "build-depends" : [],
    "test-depends" : [


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license